### PR TITLE
Bugbust timer.py aware datetimes

### DIFF
--- a/nbs/timer.ipynb
+++ b/nbs/timer.ipynb
@@ -19,17 +19,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "#hide\n",
-    "from nbdev.showdoc import *\n"
+    "from nbdev.showdoc import *"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,12 +37,13 @@
     "from nicHelper.wrappers import add_class_method,add_method,add_static_method\n",
     "from datetime import datetime, timedelta\n",
     "import logging\n",
+    "import pytz\n",
     "logger = logging.getLogger(name='timer')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,6 +69,7 @@
     "  This is the class that will be used for the timer\n",
     "  '''\n",
     "  def __init__(self):\n",
+    "    self.timezone = pytz.timezone(\"UTC\")\n",
     "    self.start_timer()\n",
     "  pass\n"
    ]
@@ -81,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,13 +93,13 @@
     "  '''\n",
     "  this method sets the starting time t0 to the current time\n",
     "  '''\n",
-    "  self.t0 = datetime.now()\n",
+    "  self.t0 = datetime.now(tz=self.timezone)\n",
     "@add_method(Timer)\n",
     "def reset_timer(self):\n",
     "  '''\n",
     "  this method resets t0 to the current time\n",
     "  '''\n",
-    "  self.t0 = datetime.now()"
+    "  self.t0 = datetime.now(tz=self.timezone)"
    ]
   },
   {
@@ -109,16 +111,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2021, 5, 15, 13, 3, 5, 822316)"
+       "datetime.datetime(2021, 7, 5, 16, 53, 22, 691668, tzinfo=<UTC>)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -137,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,30 +150,30 @@
     "  this method subtracts the current time by t0 and prints the value in seconds to find out time between start timer and this method \\n\n",
     "  description: str: this is the string to be added before the value of time taken, default = 'function took'\n",
     "  '''\n",
-    "  t1:timedelta = datetime.now() - self.t0\n",
+    "  t1:timedelta = datetime.now(tz=self.timezone) - self.t0\n",
     "  print(f'{description} :{t1.total_seconds()} s')\n",
     "  return t1.total_seconds()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "fuction took :0.019534 s\n"
+      "fuction took :0.78046 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "0.019534"
+       "0.78046"
       ]
      },
-     "execution_count": null,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -189,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,23 +210,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "test took :0.035575 s\n"
+      "test took :1.726722 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "0.035575"
+       "1.726722"
       ]
      },
-     "execution_count": null,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -242,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,7 +259,7 @@
     "  response:\n",
     "    time:float:: time in second\n",
     "  '''\n",
-    "  t1:timedelta = datetime.now() - self.t0\n",
+    "  t1:timedelta = datetime.now(tz=self.timezone) - self.t0\n",
     "  logger(f'{description} :{t1.total_seconds()} s')\n",
     "  return t1.total_seconds()"
    ]
@@ -271,16 +273,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.014992"
+       "1.252411"
       ]
      },
-     "execution_count": null,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -291,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,16 +324,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.029137"
+       "2.700026"
       ]
      },
-     "execution_count": null,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -350,9 +352,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python38",
+   "display_name": "conda_python38",
    "language": "python",
-   "name": "python38"
+   "name": "conda_python38"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/nbs/timer.ipynb
+++ b/nbs/timer.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,13 +29,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "#export\n",
     "from nicHelper.wrappers import add_class_method,add_method,add_static_method\n",
-    "from datetime import datetime, timedelta\n",
+    "from datetime import datetime, timedelta, timezone\n",
     "import logging\n",
     "import pytz\n",
     "logger = logging.getLogger(name='timer')"
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,8 +68,8 @@
     "  '''\n",
     "  This is the class that will be used for the timer\n",
     "  '''\n",
-    "  def __init__(self):\n",
-    "    self.timezone = pytz.timezone(\"UTC\")\n",
+    "  def __init__(self, tz=timezone.utc):\n",
+    "    self.timezone = tz\n",
     "    self.start_timer()\n",
     "  pass\n"
    ]
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,16 +111,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2021, 7, 5, 16, 53, 22, 691668, tzinfo=<UTC>)"
+       "datetime.datetime(2021, 7, 6, 1, 18, 5, 182361, tzinfo=datetime.timezone.utc)"
       ]
      },
-     "execution_count": 19,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,23 +157,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "fuction took :0.78046 s\n"
+      "fuction took :2.119595 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "0.78046"
+       "2.119595"
       ]
      },
-     "execution_count": 21,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,23 +210,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "test took :1.726722 s\n"
+      "test took :3.548895 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "1.726722"
+       "3.548895"
       ]
      },
-     "execution_count": 23,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -244,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,16 +273,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1.252411"
+       "1.227602"
       ]
      },
-     "execution_count": 25,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -293,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,16 +324,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "2.700026"
+       "2.47169"
       ]
      },
-     "execution_count": 27,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -355,18 +355,6 @@
    "display_name": "conda_python38",
    "language": "python",
    "name": "conda_python38"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/nbs/wrappers.ipynb
+++ b/nbs/wrappers.ipynb
@@ -273,9 +273,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python38",
+   "display_name": "conda_python38",
    "language": "python",
-   "name": "python38"
+   "name": "conda_python38"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/nicHelper/timer.py
+++ b/nicHelper/timer.py
@@ -4,7 +4,7 @@ __all__ = ['logger', 'Timer', 'start_timer', 'reset_timer', 'print_time', 'print
 
 # Cell
 from .wrappers import add_class_method,add_method,add_static_method
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import logging
 import pytz
 logger = logging.getLogger(name='timer')
@@ -14,8 +14,8 @@ class Timer:
   '''
   This is the class that will be used for the timer
   '''
-  def __init__(self):
-    self.timezone = pytz.timezone("UTC")
+  def __init__(self, tz=timezone.utc):
+    self.timezone = tz
     self.start_timer()
   pass
 

--- a/nicHelper/timer.py
+++ b/nicHelper/timer.py
@@ -6,6 +6,7 @@ __all__ = ['logger', 'Timer', 'start_timer', 'reset_timer', 'print_time', 'print
 from .wrappers import add_class_method,add_method,add_static_method
 from datetime import datetime, timedelta
 import logging
+import pytz
 logger = logging.getLogger(name='timer')
 
 # Cell
@@ -14,6 +15,7 @@ class Timer:
   This is the class that will be used for the timer
   '''
   def __init__(self):
+    self.timezone = pytz.timezone("UTC")
     self.start_timer()
   pass
 
@@ -24,13 +26,13 @@ def start_timer(self):
   '''
   this method sets the starting time t0 to the current time
   '''
-  self.t0 = datetime.now()
+  self.t0 = datetime.now(tz=self.timezone)
 @add_method(Timer)
 def reset_timer(self):
   '''
   this method resets t0 to the current time
   '''
-  self.t0 = datetime.now()
+  self.t0 = datetime.now(tz=self.timezone)
 
 # Cell
 @add_method(Timer)
@@ -39,7 +41,7 @@ def print_time(self, description = 'fuction took'):
   this method subtracts the current time by t0 and prints the value in seconds to find out time between start timer and this method \n
   description: str: this is the string to be added before the value of time taken, default = 'function took'
   '''
-  t1:timedelta = datetime.now() - self.t0
+  t1:timedelta = datetime.now(tz=self.timezone) - self.t0
   print(f'{description} :{t1.total_seconds()} s')
   return t1.total_seconds()
 
@@ -66,7 +68,7 @@ def log_time(self, description = 'fuction took', logger = logger.debug):
   response:
     time:float:: time in second
   '''
-  t1:timedelta = datetime.now() - self.t0
+  t1:timedelta = datetime.now(tz=self.timezone) - self.t0
   logger(f'{description} :{t1.total_seconds()} s')
   return t1.total_seconds()
 


### PR DESCRIPTION
The naive datetime objects are treated by many datetime methods as local times, it is preferred to use aware datetimes to represent times in UTC. The recommended way to create an aware datetime object representing a specific timestamp in UTC is by passing tzinfo as an argument to the method.